### PR TITLE
Fix return value for RVO (PR to master)

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -1,0 +1,2 @@
+Doi Yusuke
+- Return value optimization for RVO

--- a/src/feature_vector.h
+++ b/src/feature_vector.h
@@ -165,7 +165,7 @@ class FeatureVector {/*{{{*/
             }
         }
         ss << std::endl;
-        return std::move(ss.str());
+        return ss.str();
     }; /*}}}*/
 
     bool serialize(std::ofstream &os) { //{{{


### PR DESCRIPTION
optimize return value with RVO.

You should not use std::move to return value.
(except on ownership transfering)

Refarence:
- https://qiita.com/zhupeijun/items/b8f7fe3bd604192a0b0c

License:

I add unlicense to this change.
You can continue Apache license 2.0(your license) without special notice.
But, I would be grateful if you could add me to contributors.