### PR TITLE
Redefine GNU&Clang specific macros for MSVC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,12 @@ else()
 endif()
 
 set(CMAKE_CXX_STANDARD 14)
+#Ensures MSVC treats strings as UTF-8 at both compile/runtime time
+if (MSVC)
+    set(CMAKE_C_FLAGS  "${CMAKE_C_FLAGS} /utf-8")
+    set(CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} /utf-8")
+endif()
+
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 

--- a/src/util/assert.h
+++ b/src/util/assert.h
@@ -20,6 +20,8 @@
 #if defined(__clang__)
 #define JPP_BREAK_TO_DEBUGGER_IF_ATTACHED() \
   if (::jumanpp::util::asserts::isDebuggerAttached()) __builtin_debugtrap()
+#elif defined(_MSC_VER)
+#define JPP_BREAK_TO_DEBUGGER_IF_ATTACHED() __debugbreak()
 #else
 #define JPP_BREAK_TO_DEBUGGER_IF_ATTACHED() __builtin_trap()
 #endif

--- a/src/util/common.hpp
+++ b/src/util/common.hpp
@@ -5,11 +5,19 @@
 #ifndef JUMANPP_COMMON_HPP
 #define JUMANPP_COMMON_HPP
 
+#ifdef _MSC_VER
+#define JPP_ALWAYS_INLINE __forceinline
+#define JPP_NO_INLINE
+
+#define JPP_UNLIKELY(x) x
+#define JPP_LIKELY(x) x
+#else //GCC & Clang
 #define JPP_ALWAYS_INLINE __attribute__((always_inline))
 #define JPP_NO_INLINE __attribute__((noinline))
 
 #define JPP_UNLIKELY(x) __builtin_expect((x), 0)
 #define JPP_LIKELY(x) __builtin_expect(!!(x), 1)
+#endif //_MSC_VER
 
 namespace jumanpp {
 namespace util {
@@ -37,7 +45,7 @@ JPP_ALWAYS_INLINE void prefetch(const void* x);
 // Inline implementation
 // ---------------------------------------------------------------------------
 template <PrefetchHint hint>
-JPP_ALWAYS_INLINE inline void prefetch(const void* x) {
+inline JPP_ALWAYS_INLINE void prefetch(const void* x) {
 #if defined(__llvm__) || defined(__GNUC__)
   __builtin_prefetch(x, 0, hint);
 #else


### PR DESCRIPTION
P.s. I added flag `/utf-8` for MSVC just to ensure that code is compiled regardless of system's codepage as MSVC depend on it.