### PR TITLE
Windows: localtime and StlManagedAlloc

### DIFF
--- a/src/util/logging.cpp
+++ b/src/util/logging.cpp
@@ -31,6 +31,12 @@ WriteInDestructorLoggerImpl::~WriteInDestructorLoggerImpl() {
   }
 }
 
+#ifdef _MSC_VER
+inline static struct tm* localtime_r(const time_t *timep, struct tm *result) {
+    return localtime_s(result, timep) == 0 ? result : nullptr;
+}
+#endif
+
 WriteInDestructorLoggerImpl::WriteInDestructorLoggerImpl(const char *file,
                                                          int line, Level lvl)
     : level_{lvl} {

--- a/src/util/memory.hpp
+++ b/src/util/memory.hpp
@@ -166,12 +166,17 @@ class Manager {
 template <typename T>
 class StlManagedAlloc {
   PoolAlloc *core_;
+  template<typename>
+  friend class StlManagedAlloc;
 
  public:
   using value_type = T;
   using pointer = value_type *;
 
   StlManagedAlloc(PoolAlloc *core) noexcept : core_{core} {}
+  StlManagedAlloc(const StlManagedAlloc& allocator) noexcept : core_{allocator.core_} {}
+  template <typename U>
+  StlManagedAlloc(const StlManagedAlloc<U>& allocator) noexcept : core_{allocator.core_} {}
 
   pointer allocate(size_t n) { return core_->allocateRawArray<T>(n); }
 


### PR DESCRIPTION
I'll need a help with this one.
When I got to compilation to StlManagedAlloc I hit really strange error with MSVC.

It seems MS's vector header creates new instance of `StlManagedAlloc` and expects your allocator to provide copy constructor for different type.

Looking at `PoolAlloc` it deletes copy construct, but not copy/move operators.
I'm looking for advise how to proceed with it? Can I copy `PoolAlloc` at all or not?