### PR TITLE
Futher adapting for both clang-cl and msvc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ release-stage-dir/
 .vscode/
 
 # GTAGS
+*tags
 GPATH
 GRTAGS
 GTAGS

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,11 @@ set(CMAKE_CXX_STANDARD 14)
 if (MSVC)
     set(CMAKE_C_FLAGS  "${CMAKE_C_FLAGS} /utf-8")
     set(CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} /utf-8")
+
+    #Prevent the particular warning to be error
+    if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Xclang -Wno-non-pod-varargs")
+    endif()
 endif()
 
 set(CMAKE_CXX_STANDARD_REQUIRED ON)

--- a/src/core/analysis/charlattice.cc
+++ b/src/core/analysis/charlattice.cc
@@ -321,15 +321,17 @@ bool CharLattceTraversal::lookupCandidatesFrom(i32 start) {
       buffer_.push_back(s);
     }
     states2_.clear();
-    auto ptr = unique(states1_.begin(), states1_.end(),
+    //TODO: Function needs rewrite as it seems to rely on iterator being over pointers.
+    //And currently MSVC is not able to properly build it.
+    auto ptr = unique(states1_.data(), &*states1_.end(),
                       [](const TraverasalState* s1, const TraverasalState* s2) {
                         return s1->end == s2->end &&
                                s1->allFlags == s2->allFlags &&
                                s1->traversal == s2->traversal;
                       },
                       buffer_);
-    if (ptr != states1_.end()) {
-      states1_.erase(ptr, states1_.end());
+    if (ptr != &*states1_.end()) {
+      states1_.erase(states1_.begin() + (ptr - states1_.data()), states1_.end());
     }
   }
   for (auto& s : states1_) {

--- a/src/core/impl/graphviz_format.cc
+++ b/src/core/impl/graphviz_format.cc
@@ -35,7 +35,12 @@ void RenderCell::render(detail::RenderOutput *out, detail::RenderContext *ctx) {
 
 }  // namespace detail
 
-using namespace detail;
+//Use concrete imports to avoid ambigious reference to GraphVizBuilder
+using detail::RenderStringField;
+using detail::GraphVizConfig;
+using detail::RenderOutput;
+using detail::RenderContext;
+using detail::NodePtr;
 
 void GraphVizBuilder::row(std::initializer_list<StringPiece> fields,
                           std::initializer_list<detail::Attribute> attrs) {


### PR DESCRIPTION
1. Do not rely on iterator over pointers as it cannot be properly handled by MSVC
2. Disable special warning about passing POD structure to variadic function in clang-cl
3.Fix ambigious namespace issue in graphviz_format.cc due to global import of namespace details

So far so good but to be honest i think we'd need to refactor https://github.com/ku-nlp/jumanpp/blob/master/src/core/analysis/charlattice.cc#L298-L334 as it seems MSVC cannot compile properly  code that relies on iterator being over pointer.

Now i hit missing 3pp dependency so I'll need to look into:
```
d:\repos\cpp-code\jumanpp\src\rnn\simple_rnn_impl.h(8): fatal error C1083: Cannot open include file: 'eigen3/Eigen/Core': No such file or directory
```

I obviously don't have it installed and windows is not really known to be friendly toward 3pp C/C++ libs.