### PR TITLE
Install libraries and headers by "make install"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,6 +56,9 @@ else()
     message("Using Protobuf-based components... " ${Protobuf_VERSION})
 endif()
 
+include(GNUInstallDirs)
+set(JPP_INSTALL_INCLUDE_DIR "${CMAKE_INSTALL_INCLUDEDIR}/jumanpp")
+
 add_subdirectory(libs)
 add_subdirectory(test) #need to set variable here
 add_subdirectory(src)

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -18,10 +18,24 @@ macro(jpp_core_files NAME)
 endmacro()
 
 
-set(core_srcs)
-set(core_tsrcs)
-set(core_hdrs)
+set(core_srcs
+  core.cc
+  env.cc
+  features_api.cc
+  )
 
+set(core_tsrcs)
+
+set(core_hdrs
+  ${jpp_core_cfg_dir}/core_config.h
+  ${jpp_core_cfg_dir}/core_version.h
+  core.h
+  core_types.h
+  env.h
+  features_api.h
+  )
+install(FILES ${core_hdrs}
+  DESTINATION "${JPP_INSTALL_INCLUDE_DIR}/core")
 
 if (${JPP_USE_PROTOBUF})
   protobuf_generate_cpp(core_srcs core_hdrs proto/lattice_dump.proto)
@@ -37,23 +51,6 @@ add_subdirectory(input)
 add_subdirectory(spec)
 add_subdirectory(training)
 
-set(core_srcs
-  core.cc
-  env.cc
-  features_api.cc
-  ${core_srcs}
-  )
-
-set(core_hdrs
-  ${jpp_core_cfg_dir}/core_config.h
-  ${jpp_core_cfg_dir}/core_version.h
-  core.h
-  core_types.h
-  env.h
-  features_api.h
-  ${core_hdrs}
-  )
-
 set(core_test_srcs
   ${core_test_srcs}
   ${core_tsrcs}
@@ -62,6 +59,10 @@ set(core_test_srcs
   )
 
 add_library(jpp_core ${core_srcs} ${core_hdrs} ${libs3p_pegtl_headers})
+install(TARGETS jpp_core
+  RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+  LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
 jpp_test_executable(jpp_core_tests ${core_test_srcs})
 
 target_include_directories(jpp_core PUBLIC ${jpp_core_cfg_dir})

--- a/src/core/analysis/CMakeLists.txt
+++ b/src/core/analysis/CMakeLists.txt
@@ -45,7 +45,7 @@ set(core_analysis_tsrc
 
   )
 
-jpp_core_files(core_hdrs
+set(core_analysis_hdrs
 
   analysis_input.h
   analysis_result.h
@@ -77,6 +77,10 @@ jpp_core_files(core_hdrs
   unk_nodes_creator.h
 
   )
+install(FILES ${core_analysis_hdrs}
+  DESTINATION "${JPP_INSTALL_INCLUDE_DIR}/core/analysis")
+
+jpp_core_files(core_hdrs ${core_analysis_hdrs})
 
 
 jpp_test_executable(jpp_core_analysis_tests ${core_analysis_tsrc})

--- a/src/core/codegen/CMakeLists.txt
+++ b/src/core/codegen/CMakeLists.txt
@@ -20,6 +20,8 @@ set(jpp_codegen_hdrs
   partial_ngram_feature_codegen.h
   pattern_feature_codegen.h
   )
+install(FILES ${jpp_codegen_hdrs}
+  DESTINATION "${JPP_INSTALL_INCLUDE_DIR}/core/codegen")
 
 set(jpp_codegen_tsrcs
   feature_codegen_test.cc

--- a/src/core/dic/CMakeLists.txt
+++ b/src/core/dic/CMakeLists.txt
@@ -17,7 +17,7 @@ jpp_core_files(core_tsrcs
 
   )
 
-jpp_core_files(core_hdrs
+set(core_dic_hdrs
   darts.h
   darts_trie.h
   dic_build_detail.h
@@ -30,4 +30,6 @@ jpp_core_files(core_hdrs
   field_reader.h
   progress.h
   )
-
+install(FILES ${core_dic_hdrs}
+  DESTINATION "${JPP_INSTALL_INCLUDE_DIR}/core/dic")
+jpp_core_files(core_hdrs ${core_dic_hdrs})

--- a/src/core/impl/CMakeLists.txt
+++ b/src/core/impl/CMakeLists.txt
@@ -28,7 +28,7 @@ jpp_core_files(core_tsrcs
 
   )
 
-jpp_core_files(core_hdrs
+set(core_impl_hdrs
 
   feature_computer.h
   feature_debug.h
@@ -50,4 +50,6 @@ jpp_core_files(core_hdrs
   segmented_format.h
 
   )
-
+install(FILES ${core_impl_hdrs}
+  DESTINATION "${JPP_INSTALL_INCLUDE_DIR}/core/impl")
+jpp_core_files(core_hdrs ${core_impl_hdrs})

--- a/src/core/input/CMakeLists.txt
+++ b/src/core/input/CMakeLists.txt
@@ -7,7 +7,7 @@ jpp_core_files(core_srcs
   training_io.cc
   )
 
-jpp_core_files(core_hdrs
+set(core_input_hdrs
 
   partial_example.h
   partial_example_io.h
@@ -15,6 +15,9 @@ jpp_core_files(core_hdrs
   stream_reader.h
   training_io.h
   )
+install(FILES ${core_input_hdrs}
+  DESTINATION "${JPP_INSTALL_INCLUDE_DIR}/core/input")
+jpp_core_files(core_hdrs ${core_input_hdrs})
 
 jpp_core_files(core_tsrcs
   partial_example_io_test.cc

--- a/src/core/spec/CMakeLists.txt
+++ b/src/core/spec/CMakeLists.txt
@@ -15,7 +15,7 @@ set(core_spec_tsrc
 
   )
 
-jpp_core_files(core_hdrs
+set(core_spec_hdrs
 
   spec_compiler.h
   spec_dsl.h
@@ -25,7 +25,9 @@ jpp_core_files(core_hdrs
   spec_types.h
 
   )
-
+install(FILES ${core_spec_hdrs}
+  DESTINATION "${JPP_INSTALL_INCLUDE_DIR}/core/spec")
+jpp_core_files(core_hdrs ${core_spec_hdrs})
 
 jpp_test_executable(jpp_core_spec_tests ${core_spec_tsrc})
 target_link_libraries(jpp_core_spec_tests jpp_core)

--- a/src/core/training/CMakeLists.txt
+++ b/src/core/training/CMakeLists.txt
@@ -36,9 +36,15 @@ set(core_train_hdrs
   training_types.h
 
   )
+install(FILES ${core_train_hdrs}
+  DESTINATION "${JPP_INSTALL_INCLUDE_DIR}/core/train")
 
 
 add_library(jpp_core_train ${core_train_src} ${core_train_hdrs})
+install(TARGETS jpp_core_train
+  RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+  LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
 jpp_test_executable(jpp_core_train_tests ${core_train_tsrc})
 
 target_link_libraries(jpp_core_train jpp_core ${CMAKE_THREAD_LIBS_INIT})

--- a/src/jumandic/CMakeLists.txt
+++ b/src/jumandic/CMakeLists.txt
@@ -14,6 +14,10 @@ set(jumandic_tests shared/jumandic_spec_test.cc shared/mini_dic_test.cc shared/t
 set(bug_test_sources tests/bug_950111-003_test.cc tests/bug_28_lattice.cc)
 
 add_library(jpp_jumandic_spec shared/jumandic_spec.cc shared/jumandic_spec_lexdata.cc shared/jumandic_spec.h)
+install(TARGETS jpp_jumandic_spec
+  RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+  LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
 target_link_libraries(jpp_jumandic_spec jpp_core)
 
 jpp_feature_codegen(
@@ -31,9 +35,16 @@ if (${JPP_USE_PROTOBUF})
   list(APPEND jumandic_sources ${jumandic_pb_srcs})
 endif ()
 
+install(FILES ${jumandic_headers}
+  DESTINATION "${JPP_INSTALL_INCLUDE_DIR}/jumandic/shared")
+
 message(${jpp_jumandic_cg_INCLUDE})
 
 add_library(jpp_jumandic ${jumandic_sources} ${jumandic_headers} ${jpp_jumandic_cg_SRC})
+install(TARGETS jpp_jumandic
+  RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+  LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
 target_include_directories(jpp_jumandic PRIVATE ${jpp_jumandic_cg_INCLUDE})
 if (${JPP_USE_PROTOBUF})
   target_include_directories(jpp_jumandic PUBLIC ${Protobuf_INCLUDE_DIR} ${CMAKE_CURRENT_BINARY_DIR})
@@ -62,4 +73,4 @@ target_link_libraries(jumanpp_v2 jpp_jumandic)
 target_link_libraries(jumanpp_v2_train jpp_jumandic jpp_core_train)
 target_link_libraries(jpp_jumandic_pathdiff jpp_jumandic)
 
-install(PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/jumanpp_v2 RENAME jumanpp DESTINATION bin)
+install(PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/jumanpp_v2 RENAME jumanpp DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/src/rnn/CMakeLists.txt
+++ b/src/rnn/CMakeLists.txt
@@ -1,8 +1,14 @@
 set(jpp_rnn_sources mikolov_rnn.cc)
 set(jpp_rnn_includes mikolov_rnn.h simple_rnn_impl.h mikolov_rnn_impl.h)
+install(FILES ${jpp_rnn_inclues}
+  DESTINATION "${JPP_INSTALL_INCLUDE_DIR}/rnn")
 set(jpp_rnn_tests mikolov_rnn_test.cc)
 
 add_library(jpp_rnn ${jpp_rnn_sources} ${jpp_rnn_includes} )
+install(TARGETS jpp_rnn
+  RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+  LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
 add_library(jumanpp_rnn_legacy legacy/rnnlmlib.h legacy/rnnlmlib_static.h legacy/rnnlmlib_static.cpp)
 
 jpp_test_executable(jpp_rnn_tests ${jpp_rnn_tests})

--- a/src/util/CMakeLists.txt
+++ b/src/util/CMakeLists.txt
@@ -20,8 +20,14 @@ if(WIN32)
     list(APPEND jpp_util_headers win32_utils.h)
 endif()
 
+install(FILES ${jpp_util_headers}
+  DESTINATION "${JPP_INSTALL_INCLUDE_DIR}/util")
 
 add_library(jpp_util ${jpp_util_sources} ${jpp_util_headers} ${BACKWARD_headers})
+install(TARGETS jpp_util
+  RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+  LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
 jpp_test_executable(jpp_util_test ${jpp_util_test_srcs} ${jpp_util_headers})
 target_link_libraries(jpp_util_test jpp_util)
 target_include_directories(jpp_util PUBLIC ${JPP_LIBS_DIR} ${JPP_SRC_DIR})


### PR DESCRIPTION
It's needed to use Juman++ as a library.

In this change, all headers are installed. I'm not sure this is expected...
If you tell me which headers should be installed, I can choose only them.