### PR TITLE
Add note on VS2017 CMake support

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ the original Juman++.
   * We test on GCC and clang on Linux/MacOS, mingw64-gcc and MSVC2017 on Windows
 - CMake v3.1 or later
 
-Read [this document](docs/building.md) for CentOS and RHEL derivatives.
+Read [this document](docs/building.md) for CentOS and RHEL derivatives or non-CMake alternatives.
 
 ## Building from a package
 
@@ -33,12 +33,11 @@ $ cmake .. \
   -DCMAKE_INSTALL_PREFIX=<prefix> # where to install Juman++
 $ make install -j<parallelism>
 ```
-
 ## Building from git
 
 Generally, the differences between the package
 and this repository is the presence of a prebuilt model
-and absense of some development scripts.
+and absence of some development scripts.
 
 ```bash
 $ mkdir cmake-build-dir # CMake does not support in-source builds

--- a/docs/building.md
+++ b/docs/building.md
@@ -22,3 +22,20 @@ cmake .. -DCMAKE_BUILD_TYPE=Release
 make -j
 make test
 ```
+
+# Non-Cmake builds
+
+Some IDEs provide builtin support for CMake projects
+and do not require manual installation of CMake.
+
+## Visual Studio
+
+Starting since 2017 version, Visual Studio is capable to build CMake projects on its own.
+
+Before attempting, be sure to install component `Visual C++ tools for CMake`
+
+With that, you can open folder with jumanpp using `File->Open->Folder`
+
+By default it builds x86, but it is recommended to use x64 builds for release
+
+For more information on how to use CMake projects, follow [link](https://docs.microsoft.com/en-us/cpp/ide/cmake-tools-for-visual-cpp?view=vs-2017)


### PR DESCRIPTION
Just adds note to README.md that user can use builtin support of CMake in Visual studio.

Related to #91 and should be helpful to users that are not used to work with console and CMake

P.s. I'll do fix for errors in separate PR later on