### PR TITLE
Correct conversions errors from u64 to size_t(u32 on msvc32)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,5 @@ __pycache__/
 
 # Mac OS
 .DS_Store
+
+build/

--- a/src/core/analysis/rnn_scorer_gbeam.cc
+++ b/src/core/analysis/rnn_scorer_gbeam.cc
@@ -319,9 +319,9 @@ Status RnnScorerGbeamFactory::make(StringPiece rnnModelPath,
       state_->resolver.build(dic, state_->config, state_->rnnReader.words()));
   auto& h = state_->rnnReader.header();
   state_->embeddings = {state_->rnnReader.embeddings(), h.layerSize,
-                        h.vocabSize};
+                        static_cast<jumanpp::size_t>(h.vocabSize)};
   state_->nceEmbeddings = {state_->rnnReader.nceEmbeddings(), h.layerSize,
-                           h.vocabSize};
+                           static_cast<jumanpp::size_t>(h.vocabSize)};
   if (h.layerSize > 64 * 1024) {
     return JPPS_NOT_IMPLEMENTED << "we don't support embed sizes > 64k";
   }

--- a/src/core/analysis/score_processor.cc
+++ b/src/core/analysis/score_processor.cc
@@ -195,7 +195,7 @@ util::ArraySlice<BeamCandidate> processBeamCandidates(
     candidates = util::MutableArraySlice<BeamCandidate>{candidates, 0, sz};
   }
   std::sort(candidates.begin(), candidates.end(), comp);
-  auto size = std::min<u64>(maxBeam, candidates.size());
+  auto size = std::min<jumanpp::size_t>(maxBeam, candidates.size());
   return util::ArraySlice<BeamCandidate>{candidates, 0, size};
 }
 

--- a/src/rnn/mikolov_rnn.cc
+++ b/src/rnn/mikolov_rnn.cc
@@ -182,25 +182,25 @@ Status MikolovModelReader::parse() {
   data_->alloc = data_->memmgr.value().core();
   auto& alloc = data_->alloc;
 
-  const auto embedding_size = static_cast<size_t>(hdr.layerSize) * static_cast<size_t>(hdr.vocabSize);
-  const auto matrix_size = static_cast<size_t>(hdr.layerSize) * static_cast<size_t>(hdr.layerSize);
+  const auto embedding_matrix_size = static_cast<size_t>(hdr.layerSize) * static_cast<size_t>(hdr.vocabSize);
+  const auto transition_matrix_size = static_cast<size_t>(hdr.layerSize) * static_cast<size_t>(hdr.layerSize);
 
   data_->embeddingData =
-      alloc->allocateBuf<float>(embedding_size, 64);
+      alloc->allocateBuf<float>(embedding_matrix_size, 64);
   data_->nceEmbeddingData =
-      alloc->allocateBuf<float>(embedding_size, 64);
+      alloc->allocateBuf<float>(embedding_matrix_size, 64);
   data_->matrixData =
-      alloc->allocateBuf<float>(matrix_size, 64);
+      alloc->allocateBuf<float>(transition_matrix_size, 64);
   data_->maxentWeightData = alloc->allocateBuf<float>(static_cast<size_t>(hdr.maxentSize), 64);
 
   JPP_RIE_MSG(copyArray(contents, data_->embeddingData,
-                        embedding_size, &start),
+                        embedding_matrix_size, &start),
               "embeds");
   JPP_RIE_MSG(copyArray(contents, data_->nceEmbeddingData,
-                        embedding_size, &start),
+                        embedding_matrix_size, &start),
               "nce embeds");
   JPP_RIE_MSG(copyArray(contents, data_->matrixData,
-                        matrix_size, &start),
+                        transition_matrix_size, &start),
               "matrix");
   JPP_RIE_MSG(
       copyArray(contents, data_->maxentWeightData, static_cast<size_t>(hdr.maxentSize), &start),


### PR DESCRIPTION
There are still lots of warnings due to conversions between 32/64 bit integers, but I fixed only errors and these warnings around them.

Users should be able build it with msvc32 compiler

Closes  #91