### PR TITLE
Fix the runtime error of jpp_codegen_tests.

### DIFF
--- a/src/core/codegen/CMakeLists.txt
+++ b/src/core/codegen/CMakeLists.txt
@@ -32,5 +32,5 @@ add_library(jpp_core_codegen ${jpp_codegen_srcs} ${jpp_codegen_hdrs})
 
 jpp_test_executable(jpp_codegen_tests ${jpp_codegen_tsrcs})
 target_include_directories(jpp_codegen_tests PRIVATE ${cgtest02_INCLUDE})
-target_link_libraries(jpp_core_codegen jpp_core)
-target_link_libraries(jpp_codegen_tests jpp_core_codegen)
+target_link_libraries(jpp_core_codegen pthread jpp_core)
+target_link_libraries(jpp_codegen_tests pthread jpp_core_codegen)


### PR DESCRIPTION
This pull request fixes the following error, which occurs when building JUMAN++.

```
$ mkdir build
$ cd build
$ cmake ..
$ make
(snip)
[ 69%] Linking CXX executable cgtest02_codegen_binary
[ 69%] Built target cgtest02_codegen_binary
[ 69%] Generating gen/cgtest02.cc, gen/cgtest02.h
terminate called after throwing an instance of 'std::system_error'
  what():  Unknown error -1
Aborted
src/core/codegen/CMakeFiles/jpp_codegen_tests.dir/build.make:62: ターゲット 'src/core/codegen/gen/cgtest02.cc' のレシピで失敗しました
make[2]: *** [src/core/codegen/gen/cgtest02.cc] エラー 134
CMakeFiles/Makefile2:741: ターゲット 'src/core/codegen/CMakeFiles/jpp_codegen_tests.dir/all' のレシピで失敗しました
make[1]: *** [src/core/codegen/CMakeFiles/jpp_codegen_tests.dir/all] エラー 2
Makefile:138: ターゲット 'all' のレシピで失敗しました
make: *** [all] エラー 2
```