### PR TITLE
add Dockerfile for Juman++

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM alpine:latest AS builder
+RUN apk add alpine-sdk cmake libexecinfo-dev protobuf-dev curl
+COPY . /root
+RUN /bin/sh /root/script/make-jpp-alpine-x64.sh
+
+FROM alpine:latest as runner
+RUN apk add --no-cache libexecinfo libstdc++
+COPY --from=builder /root/bld-docker-dist/usr/local /usr/local
+ENTRYPOINT ["/usr/local/bin/jumanpp"]

--- a/do_format.sh
+++ b/do_format.sh
@@ -1,6 +1,5 @@
-#/bin/sh
+#!/bin/sh
 
 #find -E src -regex '.+\.(cc|cpp|h|hpp|proto)' -print0 | xargs -0 clang-format -i
 git add .
-exec python $(dirname $0)/script/git-clang-format.py $*
-git add .
+exec python "$(dirname "$0")/script/git-clang-format.py" "$*"

--- a/make_release.sh
+++ b/make_release.sh
@@ -2,26 +2,31 @@
 
 set -x
 
-if [ -z ${VERSION+x} ]; then
+if [[ -z ${VERSION+x} ]]; then
     echo "VERSION variable must be defined"
     exit 1
 fi
 
-if ! [ -f ${MODEL} ]; then
+if [[ ! -f "${MODEL}" ]]; then
     echo "MODEL variable must be defined and point to file"
     exit 1
 fi
 
-OUT_DIR="release-stage-dir/jumanpp-${VERSION}"
+OUT_ROOT=${OUT_ROOT:-}
+
+OUT_DIR="${OUT_ROOT}/release-stage-dir/jumanpp-${VERSION}"
 
 mkdir -p "${OUT_DIR}"
 
 cp -r cmake docs libs src test CMakeLists.txt \
-    CONTRIBUTORS README.md README_ja.md \
-    "release-stage-dir/jumanpp-${VERSION}"
+    CONTRIBUTORS README.md Dockerfile \
+    "${OUT_DIR}"
+
+mkdir -p "${OUT_DIR}/script"
+cp script/*.sh "${OUT_DIR}/script"
 
 echo "set(PROJECT_VERSION ${VERSION})" > "${OUT_DIR}/version.cmake"
 
 cp -r model-template "${OUT_DIR}/model"
 
-cp ${MODEL} "${OUT_DIR}/model/jumandic.jppmdl"
+cp "${MODEL}" "${OUT_DIR}/model/jumandic.jppmdl"

--- a/script/build-pgo.sh
+++ b/script/build-pgo.sh
@@ -1,0 +1,88 @@
+#!/bin/sh
+
+# This script builds Juman++ with Profile-Guided Optimizations & Link-Time optimizations
+
+FULL_NAME=$(readlink -f "$0")
+
+SCRIPT_DIR=$(dirname "$FULL_NAME")
+
+JPP_SRC=$(dirname "$SCRIPT_DIR")
+
+JPP_ARCH=x86-64-v2
+
+JPP_DATA=
+
+for i in "$@"; do
+  case $i in
+    --arch=*)
+      JPP_ARCH="${i#*=}"
+      shift
+      ;;
+    --data=*)
+      JPP_DATA="${i#*=}"
+      shift
+      ;;
+    --model=*)
+      JPP_MODEL="${i#*=}"
+      shift
+      ;;
+    -DCMAKE_CXX_FLAGS=*)
+      JPP_CXX_FLAGS="${i#*=}"
+      shift
+      ;;
+    *)
+      shift
+      ;;
+  esac
+done
+
+if [ ! -f "$JPP_DATA" ]; then
+  echo "Data for PGO collection was not passed. Pass a file with Japanese text."
+  exit 1
+fi
+
+if [ ! -f "$JPP_MODEL" ]; then
+  echo "Juman++ model was not passed"
+  exit 1
+fi
+
+
+BLD_DIR_NAME=bld-${JPP_ARCH}
+
+JPP_BLD="$JPP_SRC/$BLD_DIR_NAME"
+
+mkdir -p "$JPP_BLD"
+
+#delete PGO data
+rm -rf  "/tmp/jpp-bld/prof-${JPP_ARCH}"
+
+# GCC 10.1+ supports -fprofile-prefix-path=$JPP_SRC
+
+# Configure collection of profile data
+cmake -S "$JPP_SRC" -B "$JPP_BLD" \
+    -DJPP_ENABLE_TESTS=FALSE \
+    -DJPP_MAX_DIC_FIELDS=10 \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_CXX_FLAGS="-march=$JPP_ARCH -fprofile-dir=/tmp/jpp-bld/prof-${JPP_ARCH} -fprofile-generate -flto -fuse-linker-plugin ${JPP_CXX_FLAGS}" \
+    -DCMAKE_CXX_FLAGS_RELEASE='-Ofast -fgcse-sm -fgcse-las -fipa-pta -ffast-math -ffinite-math-only -fno-signed-zeros -fomit-frame-pointer -DNDEBUG'
+
+# Compile profile-collecting binary
+nice -n19 cmake --build "$JPP_BLD" --parallel -- jumanpp_v2
+
+# Collect profiling data
+echo "Collecting PGO data for $JPP_ARCH"
+nice "$JPP_BLD/src/jumandic/jumanpp_v2" "--model=${JPP_MODEL}" "$JPP_DATA" --format=juman -o /dev/null
+nice "$JPP_BLD/src/jumandic/jumanpp_v2" "--model=${JPP_MODEL}" "$JPP_DATA" --format=lattice -o /dev/null
+
+# Configure PGO compilation
+cmake -S "$JPP_SRC" -B "$JPP_BLD" \
+    -DJPP_ENABLE_TESTS=FALSE \
+    -DJPP_ENABLE_TESTS=FALSE \
+    -DJPP_MAX_DIC_FIELDS=10 \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_CXX_FLAGS="-march=$JPP_ARCH -fprofile-dir=/tmp/jpp-bld/prof-${JPP_ARCH} -fprofile-use -flto -fuse-linker-plugin ${JPP_CXX_FLAGS}" \
+    -DCMAKE_CXX_FLAGS_RELEASE='-Ofast -fgcse-sm -fgcse-las -fipa-pta -ffast-math -ffinite-math-only -fno-signed-zeros -fomit-frame-pointer -DNDEBUG'
+
+# Build final binary
+nice -n19 cmake --build "$JPP_BLD" --parallel -- jumanpp_v2
+

--- a/script/jumanpp-multiarch.sh
+++ b/script/jumanpp-multiarch.sh
@@ -1,0 +1,52 @@
+#!/bin/sh
+# Select Juman++ binary which is compiled with extended instruction set
+
+# https://unix.stackexchange.com/questions/631217/how-do-i-check-if-my-cpu-supports-x86-64-v2
+awk -f - <<EOF
+BEGIN {
+    while (!/flags/) if (getline < "/proc/cpuinfo" != 1) exit 1
+    if (/lm/&&/cmov/&&/cx8/&&/fpu/&&/fxsr/&&/mmx/&&/syscall/&&/sse2/) level = 1
+    if (level == 1 && /cx16/&&/lahf/&&/popcnt/&&/sse4_1/&&/sse4_2/&&/ssse3/) level = 2
+    if (level == 2 && /avx/&&/avx2/&&/bmi1/&&/bmi2/&&/f16c/&&/fma/&&/abm/&&/movbe/&&/xsave/) level = 3
+    if (level == 3 && /avx512f/&&/avx512bw/&&/avx512cd/&&/avx512dq/&&/avx512vl/) level = 4
+    if (level > 0) { exit level + 1 }
+    exit 1
+}
+EOF
+
+LEVEL=$?
+
+FULL_NAME=$(readlink -f "$0")
+RUN_DIR=$(dirname "$FULL_NAME")
+
+if [ $LEVEL -ge 5 ]; then # avx-512 compatible
+  ARCH="x86-64-v4"
+  EXE="$RUN_DIR/jumanpp-$ARCH"
+  if [[ -x "$EXE" ]]; then
+    exec "$EXE" "$@"
+  fi
+fi
+
+if [ $LEVEL -ge 4 ]; then # avx2/fma/bmi2
+  ARCH="x86-64-v3"
+  EXE="$RUN_DIR/jumanpp-$ARCH"
+  if [[ -x "$EXE" ]]; then
+    exec "$EXE" "$@"
+  fi
+fi
+
+if [ $LEVEL -ge 3 ]; then # sse 4.1/popcnt
+  ARCH="x86-64-v2"
+  EXE="$RUN_DIR/jumanpp-$ARCH"
+  if [[ -x "$EXE" ]]; then
+    exec "$EXE" "$@"
+  fi
+fi
+
+EXE="$RUN_DIR/jumanpp-default"
+if [[ -x "$EXE" ]]; then
+  exec "$EXE" "$@"
+fi
+
+echo "Failed to resolve correct jumanpp executable" >&2
+exit 1

--- a/script/make-jpp-alpine-x64.sh
+++ b/script/make-jpp-alpine-x64.sh
@@ -1,0 +1,75 @@
+#!/bin/sh
+
+set -x
+
+# https://unix.stackexchange.com/questions/631217/how-do-i-check-if-my-cpu-supports-x86-64-v2
+awk -f - <<EOF
+BEGIN {
+    while (!/flags/) if (getline < "/proc/cpuinfo" != 1) exit 1
+    if (/lm/&&/cmov/&&/cx8/&&/fpu/&&/fxsr/&&/mmx/&&/syscall/&&/sse2/) level = 1
+    if (level == 1 && /cx16/&&/lahf/&&/popcnt/&&/sse4_1/&&/sse4_2/&&/ssse3/) level = 2
+    if (level == 2 && /avx/&&/avx2/&&/bmi1/&&/bmi2/&&/f16c/&&/fma/&&/abm/&&/movbe/&&/xsave/) level = 3
+    if (level == 3 && /avx512f/&&/avx512bw/&&/avx512cd/&&/avx512dq/&&/avx512vl/) level = 4
+    if (level > 0) { exit level + 1 }
+    exit 1
+}
+EOF
+
+LEVEL=$?
+
+FULL_NAME=$(readlink -f "$0")
+
+SCRIPT_DIR=$(dirname "$FULL_NAME")
+
+JPP_SRC=$(dirname "$SCRIPT_DIR")
+
+MODEL_FILE="$JPP_SRC/model/jumandic.jppmdl"
+
+TEXT_DATA="$JPP_SRC/model/pgo-train.txt"
+
+if [[ ! -f "$MODEL_FILE" ]]; then
+  echo "Model file $MODEL_FILE was not found"
+  exit 1
+fi
+
+if [[ ! -f "$TEXT_DATA" ]]; then
+  # download file
+  curl -L https://github.com/ku-nlp/KWDLC/releases/download/release_1_0/leads.org.txt.gz | gzip -dc > "$TEXT_DATA"
+fi
+
+# build and install default version
+$SHELL "$SCRIPT_DIR/build-pgo.sh" "--arch=x86-64" "--model=$MODEL_FILE" "--data=$TEXT_DATA" -DCMAKE_CXX_FLAGS=-U_FORTIFY_SOURCE
+
+# this will install default config/model to /usr/local
+cmake --install "$JPP_SRC/bld-x86-64"
+
+RESDIR="$JPP_SRC/bld-docker-dist/usr/local"
+
+install -m 0755 -D /usr/local/bin/jumanpp "$JPP_SRC/bld-docker-dist/usr/local/bin/jumanpp-default"
+install -m 0644 -D /usr/local/libexec/jumanpp/jumandic.jppmdl "$RESDIR/libexec/jumanpp/jumandic.jppmdl"
+install -m 0644 -D /usr/local/libexec/jumanpp/jumandic.config "$RESDIR/libexec/jumanpp/jumandic.config"
+
+# TODO: when alpine will have GCC 11.*, change architectures to generic ones (x86-64-v*)
+
+# build and install nehalem-compatible version
+if [[ $LEVEL -ge 3 ]]; then # sse 4.1
+$SHELL "$SCRIPT_DIR/build-pgo.sh" "--arch=nehalem" "--model=$MODEL_FILE" "--data=$TEXT_DATA" -DCMAKE_CXX_FLAGS=-U_FORTIFY_SOURCE
+install -m 0755 -D "$JPP_SRC/bld-nehalem/src/jumandic/jumanpp_v2" "$RESDIR/bin/jumanpp-x86-64-v2"
+fi
+
+# build and install haswell-compatible version
+if [[ $LEVEL -ge 4 ]]; then # avx2/fma
+$SHELL "$SCRIPT_DIR/build-pgo.sh" "--arch=haswell" "--model=$MODEL_FILE" "--data=$TEXT_DATA" -DCMAKE_CXX_FLAGS=-U_FORTIFY_SOURCE
+install -m 0755 -D "$JPP_SRC/bld-haswell/src/jumandic/jumanpp_v2" "$RESDIR/bin/jumanpp-x86-64-v3"
+fi
+
+
+# finally, avx-512 version
+# TODO: enable with GCC 11.*
+#if [[ $LEVEL -ge 5 ]]; then # avx-512 compatible
+#$SHELL "$SCRIPT_DIR/build-pgo.sh" "--arch=x86-64-v4" "--model=$MODEL_FILE" "--data=$TEXT_DATA" -DCMAKE_CXX_FLAGS=-U_FORTIFY_SOURCE
+#install -m 0755 -D "$JPP_SRC/bld-x86-64-v4/src/jumandic/jumanpp_v2" "$RESDIR/bin/jumanpp-x86-64-v4"
+#fi
+
+# and finally, runner script
+install -m 0755 -D "$SCRIPT_DIR/jumanpp-multiarch.sh" "$RESDIR/bin/jumanpp"


### PR DESCRIPTION
Docker build is based on Alpine and uses PGO and LTO.
It builds several binaries for several types of CPU features,
selecting the correct binary at the runtime.

Creating such packaging should be the recommended way to build/use Juman++ from now on.