### PR TITLE
fix: out-of-bounds read in NumericUnkMaker::checkPeriod (closes #157)

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -52,7 +52,7 @@ jobs:
         shell: bash
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install dependencies (Ubuntu)
         if: startsWith(matrix.os, 'ubuntu-')

--- a/src/core/analysis/numeric_creator.cc
+++ b/src/core/analysis/numeric_creator.cc
@@ -245,7 +245,7 @@ size_t NumericUnkMaker::checkPeriod(const CodepointStorage &codepoints,
   if (pos == 0) return 0;
   if (!codepoints[posPeriod].hasClass(PeriodClass)) return 0;
   if (!codepoints[posPeriod - 1].hasClass(charClass_)) return 0;
-  if (pos + 1 < codepoints.size() &&
+  if (posPeriod + 1 < codepoints.size() &&
       codepoints[posPeriod + 1].hasClass(charClass_))
     return 1;
   return 0;

--- a/src/core/analysis/numeric_creator_test.cc
+++ b/src/core/analysis/numeric_creator_test.cc
@@ -243,6 +243,27 @@ TEST_CASE("do not make numeric unk nodes ends with period") {
   CHECK(env.numNodeSeeds() == 1);
 }
 
+// Regression for ku-nlp/jumanpp#157: trailing digit+period caused a read
+// past the end of the codepoint vector during the second spawnNodes pass
+// (start > 0), because checkPeriod bounded the lookahead against `pos`
+// instead of the absolute position `start + pos`.
+TEST_CASE("multi-digit number followed by trailing period does not crash") {
+  NumericTestEnv env{"x,l1\nほげ,l2\n"};
+  env.analyze("１０．");
+  CHECK(env.contains("１０", 0, "l1"));
+  CHECK(env.contains("０", 1, "l1"));
+  CHECK(!env.contains("１０．", 0, "l1"));
+  CHECK(!env.contains("０．", 1, "l1"));
+  CHECK(env.numNodeSeeds() == 2);
+}
+
+TEST_CASE("digit+period preceded by non-numeric context does not crash") {
+  NumericTestEnv env{"x,l1\nほげ,l2\n"};
+  env.analyze("ほげ４．");
+  CHECK(env.contains("４", 2, "l1"));
+  CHECK(!env.contains("４．", 2, "l1"));
+}
+
 TEST_CASE("do not make numeric unk nodes starts with period") {
   NumericTestEnv env{"x,l1\nほげ,l2\n"};
   env.analyze("．４");


### PR DESCRIPTION
## Summary

- **Fix #157.** `NumericUnkMaker::checkPeriod` bounded the lookahead with `pos + 1 < codepoints.size()` but read `codepoints[posPeriod + 1]`, where `posPeriod = start + pos`. On the second `spawnNodes` pass (`start > 0`), the two diverge and inputs like `１０．` or `ほげ４．` read one past the end of the codepoint vector — the crash Ozeki-san reported from Windows. Reproduced on Linux under libstdc++ debug mode.
- Replaced the wrong guard with `posPeriod + 1 < codepoints.size()`. Audited the sibling helpers (`checkInterfix`, `checkSuffix`, `checkPrefix`, `checkComma`) — they already bound correctly, so the bug is isolated to `checkPeriod`.
- Added two regression tests covering the repro (`１０．`) and the `start > 0` path (`ほげ４．`). Both abort on the prior code.
- Bumped `actions/checkout@v4` → `v5` to clear the Node 20 deprecation warning the newly-rewritten workflow surfaced.

## Test plan

- [x] `ctest --test-dir build-asan --output-on-failure` passes 10/10 suites under AddressSanitizer + UBSan + libstdc++ debug mode.
- [x] New `numeric_creator_test` cases `multi-digit number followed by trailing period does not crash` and `digit+period preceded by non-numeric context does not crash` abort on `master` before the fix, pass after.
- [x] CI green across the linux/linux-asan/macOS/Windows matrix introduced in c2b8b59.

Closes #157.